### PR TITLE
Fix ratio step size on DimensionSelectorWithSeedNode

### DIFF
--- a/randomness.py
+++ b/randomness.py
@@ -57,8 +57,8 @@ class DimensionSelectorWithSeedNode:
         return {
             "required": {
                 "resolution": ("INT", {"default": 1024}),
-                "min_ratio": ("FLOAT", {"default": 0.6}),
-                "max_ratio": ("FLOAT", {"default": 1.6}),
+                "min_ratio": ("FLOAT", {"default": 0.6, "step": 0.01}),
+                "max_ratio": ("FLOAT", {"default": 1.6, "step": 0.01}),
                 "multiples": ("INT", {"default": 32}),
                 "seed": ("INT", {"default": 0}),
             }


### PR DESCRIPTION
`min_ratio` and `max_ratio` don't define a step, so ComfyUI defaults to 0.1. You can't set anything between those increments (e.g. 0.95 snaps to 0.9).

Added `"step": 0.01` to both inputs.

Fixes #26